### PR TITLE
Fix incorrect upper bounds

### DIFF
--- a/sexpr-parser.cabal
+++ b/sexpr-parser.cabal
@@ -23,7 +23,7 @@ library
     , Text.SExpression.Types
   build-depends:
       base              >= 4.9 && < 5
-    , megaparsec        >= 6.5 && < 8
+    , megaparsec        >= 6.5 && < 7.1
 
 test-suite sexpr-parser-spec
   type:                 exitcode-stdio-1.0
@@ -34,8 +34,8 @@ test-suite sexpr-parser-spec
       Text.SExpression.InternalSpec
   build-depends:
       base              >= 4.9 && < 5
-    , hspec             >= 2.5 && < 3
-    , megaparsec        >= 6.5 && < 8
+    , hspec             >= 2.5 && < 2.8
+    , megaparsec        >= 6.5 && < 7.1
     , sexpr-parser
 
 executable sexpr-parser-z3-demo
@@ -44,7 +44,7 @@ executable sexpr-parser-z3-demo
   main-is:              Main.hs
   build-depends:
       base              >= 4.9 && < 5
-    , bytestring        >= 0.10 && < 1
-    , megaparsec        >= 6.5 && < 8
-    , process           >= 1.6 && < 2
+    , bytestring        >= 0.10 && < 0.11
+    , megaparsec        >= 6.5 && < 7.1
+    , process           >= 1.6 && < 1.7
     , sexpr-parser


### PR DESCRIPTION
Haskell's ecosystem uses the [PVP](https://pvp.haskell.org/faq) which differs from SemVer
and as such "single-digit upper bounds" are unsound for Hackage.