### PR TITLE
Overriding literal parsers

### DIFF
--- a/lib/Text/SExpression.hs
+++ b/lib/Text/SExpression.hs
@@ -29,8 +29,7 @@ s-expressions) to display the satisfying assignment for the expression.
 > import Text.Megaparsec (parse)
 > import Text.Megaparsec.Char (char, string)
 > import Text.Printf (printf)
-> import Text.SExpression (Parser, SExpr(..), parseSExpr)
->
+> import Text.SExpression (Parser, SExpr(..), parseSExpr, def)
 > data Z3SATResult = Satisfied | Unsatisfied deriving Show
 >
 > data Z3Output = Z3Output Z3SATResult SExpr deriving Show
@@ -63,7 +62,7 @@ s-expressions) to display the satisfying assignment for the expression.
 >         _ -> error "Unreachable"
 >
 > parseZ3Output :: Parser Z3Output
-> parseZ3Output = Z3Output <$> parseZ3SATResult <*> parseSExpr
+> parseZ3Output = Z3Output <$> parseZ3SATResult <*> parseSExpr def
 >
 > checkSATWithZ3 :: String -> String -> IO (Either String (Z3SATResult, [(String, Bool)]))
 > checkSATWithZ3 ctx input = do
@@ -106,7 +105,7 @@ module Text.SExpression
       SExpr(..)
     , -- * S-expression parser
       parseSExpr
-    , -- * Polymorhic default value
+    , -- * Polymorphic default value
       def
     ) where
 

--- a/lib/Text/SExpression.hs
+++ b/lib/Text/SExpression.hs
@@ -106,7 +106,10 @@ module Text.SExpression
       SExpr(..)
     , -- * S-expression parser
       parseSExpr
+    , -- * Polymorhic default value
+      def
     ) where
 
+import Data.Default (def)
 import Text.SExpression.Internal (parseSExpr)
 import Text.SExpression.Types (Parser, SExpr(..))

--- a/lib/Text/SExpression/Default.hs
+++ b/lib/Text/SExpression/Default.hs
@@ -82,8 +82,8 @@ instance Default LiteralParsers where
 -- | Smart constructor for parser configuration
 --   that allows overriding the default literal parsers
 mkLiteralParsers ::
-  (LiteralParsersM -> LiteralParsersM) -> -- ^ Cumulative override function
-  LiteralParsers
+     (LiteralParsersM -> LiteralParsersM) -- ^ Cumulative override function
+  -> LiteralParsers
 mkLiteralParsers f =
   case f def of
     LiteralParsersM{..} ->
@@ -93,9 +93,8 @@ mkLiteralParsers f =
         LiteralParsers parseString parseNumber parseBool
 
 -- | String parser override function
-overrideStringP ::
-  Parser SExpr -> -- ^ String parser
-  (LiteralParsersM ->  LiteralParsersM)
+overrideStringP :: Parser SExpr -- ^ String parser
+  -> (LiteralParsersM ->  LiteralParsersM)
 overrideStringP sp lp = lp <>
   LiteralParsersM
   { parseStringM = Just $ Last sp
@@ -104,9 +103,8 @@ overrideStringP sp lp = lp <>
   }
 
 -- | Number parser override function
-overrideNumberP ::
-  Parser SExpr -> -- ^ Number parser
-  (LiteralParsersM ->  LiteralParsersM)
+overrideNumberP :: Parser SExpr -- ^ Number parser
+  -> (LiteralParsersM ->  LiteralParsersM)
 overrideNumberP np lp = lp <>
   LiteralParsersM
   { parseStringM = Nothing
@@ -115,9 +113,8 @@ overrideNumberP np lp = lp <>
   }
 
 -- | Boolean parser override function
-overrideBoolP ::
-  Parser SExpr -> -- ^ Bool parser
-  (LiteralParsersM ->  LiteralParsersM)
+overrideBoolP :: Parser SExpr -- ^ Bool parser
+  -> (LiteralParsersM ->  LiteralParsersM)
 overrideBoolP bp lp = lp <>
   LiteralParsersM
   { parseStringM = Nothing

--- a/lib/Text/SExpression/Default.hs
+++ b/lib/Text/SExpression/Default.hs
@@ -52,6 +52,22 @@ data LiteralParsers = LiteralParsers
   , parseBool   :: Parser SExpr
   }
 
+instance Semigroup LiteralParsersM where
+  (<>)
+    (LiteralParsersM ps pn pb)
+    (LiteralParsersM ps' pn' pb') =
+    LiteralParsersM (ps <> ps') (pn <> pn') (pb <> pb')
+
+instance Default LiteralParsersM where
+  def = LiteralParsersM
+        { parseStringM = Just $ Last parseStringDef
+        , parseNumberM = Just $ Last parseNumberDef
+        , parseBoolM   = Just $ Last parseBoolDef
+        }
+
+instance Default LiteralParsers where
+  def = mkLiteralParsers def
+
 mkLiteralParsers ::
   (LiteralParsersM -> LiteralParsersM) ->
   LiteralParsers
@@ -90,12 +106,6 @@ overrideBoolP bp lp = lp <>
   , parseBoolM   = Just $ Last bp
   }
   
-instance Semigroup LiteralParsersM where
-  (<>)
-    (LiteralParsersM ps pn pb)
-    (LiteralParsersM ps' pn' pb') =
-    LiteralParsersM (ps <> ps') (pn <> pn') (pb <> pb')
-
 -- | Default parser for s-expression boolean literals
 parseBoolDef ::
   Parser SExpr
@@ -120,13 +130,3 @@ parseStringDef = do
     s <- many (noneOf "\"")
     void $ char '"'
     pure $ String s
-
-instance Default LiteralParsersM where
-  def = LiteralParsersM
-        { parseStringM = Just $ Last parseStringDef
-        , parseNumberM = Just $ Last parseNumberDef
-        , parseBoolM   = Just $ Last parseBoolDef
-        }
-
-instance Default LiteralParsers where
-  def = mkLiteralParsers def

--- a/lib/Text/SExpression/Default.hs
+++ b/lib/Text/SExpression/Default.hs
@@ -1,7 +1,6 @@
-{-# OPTIONS_GHC -Wall #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}
 
 #undef MEGAPARSEC_7_OR_LATER

--- a/lib/Text/SExpression/Default.hs
+++ b/lib/Text/SExpression/Default.hs
@@ -14,7 +14,17 @@
 #endif
 #endif
 
-module Text.SExpression.Default where
+module Text.SExpression.Default
+  ( LiteralParsers(..)
+  , LiteralParsersM
+  , mkLiteralParsers
+  , overrideStringP
+  , overrideNumberP
+  , overrideBoolP
+  , parseStringDef
+  , parseNumberDef
+  , parseBoolDef
+  ) where
 
 import Data.Semigroup (Last(..))
 import Data.Default
@@ -39,12 +49,14 @@ import Text.Megaparsec.Char
 #endif
     )
 
+-- | Partial parser configuration
 data LiteralParsersM = LiteralParsersM
   { parseStringM :: Maybe (Last (Parser SExpr))
   , parseNumberM :: Maybe (Last (Parser SExpr))
   , parseBoolM   :: Maybe (Last (Parser SExpr))
   }
 
+-- | Fully defined parser configuration
 data LiteralParsers = LiteralParsers
   { parseString :: Parser SExpr
   , parseNumber :: Parser SExpr
@@ -67,8 +79,10 @@ instance Default LiteralParsersM where
 instance Default LiteralParsers where
   def = mkLiteralParsers def
 
+-- | Smart constructor for parser configuration
+--   that allows overriding the default literal parsers
 mkLiteralParsers ::
-  (LiteralParsersM -> LiteralParsersM) ->
+  (LiteralParsersM -> LiteralParsersM) -> -- ^ Cumulative override function
   LiteralParsers
 mkLiteralParsers f =
   case f def of
@@ -78,8 +92,10 @@ mkLiteralParsers f =
           Just (Last parseBool)   = parseBoolM in
         LiteralParsers parseString parseNumber parseBool
 
+-- | String parser override function
 overrideStringP ::
-  Parser SExpr -> LiteralParsersM ->  LiteralParsersM
+  Parser SExpr -> -- ^ String parser
+  (LiteralParsersM ->  LiteralParsersM)
 overrideStringP sp lp = lp <>
   LiteralParsersM
   { parseStringM = Just $ Last sp
@@ -87,8 +103,10 @@ overrideStringP sp lp = lp <>
   , parseBoolM   = Nothing
   }
 
+-- | Number parser override function
 overrideNumberP ::
-  Parser SExpr -> LiteralParsersM ->  LiteralParsersM
+  Parser SExpr -> -- ^ Number parser
+  (LiteralParsersM ->  LiteralParsersM)
 overrideNumberP np lp = lp <>
   LiteralParsersM
   { parseStringM = Nothing
@@ -96,8 +114,10 @@ overrideNumberP np lp = lp <>
   , parseBoolM   = Nothing
   }
 
+-- | Boolean parser override function
 overrideBoolP ::
-  Parser SExpr -> LiteralParsersM ->  LiteralParsersM
+  Parser SExpr -> -- ^ Bool parser
+  (LiteralParsersM ->  LiteralParsersM)
 overrideBoolP bp lp = lp <>
   LiteralParsersM
   { parseStringM = Nothing

--- a/lib/Text/SExpression/Default.hs
+++ b/lib/Text/SExpression/Default.hs
@@ -1,0 +1,132 @@
+{-# OPTIONS_GHC -Wall #-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecordWildCards #-}
+
+#undef MEGAPARSEC_7_OR_LATER
+#ifdef MIN_VERSION_GLASGOW_HASKELL
+-- GHC >= 7.10.1.0
+#if MIN_VERSION_GLASGOW_HASKELL(8,0,0,0)
+-- GHC >= 8.0.0.0
+#if MIN_VERSION_megaparsec(7,0,0)
+#define MEGAPARSEC_7_OR_LATER
+#endif
+#endif
+#endif
+
+module Text.SExpression.Default where
+
+import Data.Semigroup (Last(..))
+import Data.Default
+import Text.SExpression.Types (SExpr(..), Parser)
+import Control.Monad (void)
+import Text.Megaparsec
+    ( (<|>)
+    , many
+    , notFollowedBy
+#ifdef MEGAPARSEC_7_OR_LATER
+    , noneOf
+#endif
+    , some
+    )
+import Text.Megaparsec.Char
+    ( char
+    , digitChar
+    , string
+    , alphaNumChar
+#ifndef MEGAPARSEC_7_OR_LATER
+    , noneOf
+#endif
+    )
+
+data LiteralParsersM = LiteralParsersM
+  { parseStringM :: Maybe (Last (Parser SExpr))
+  , parseNumberM :: Maybe (Last (Parser SExpr))
+  , parseBoolM   :: Maybe (Last (Parser SExpr))
+  }
+
+data LiteralParsers = LiteralParsers
+  { parseString :: Parser SExpr
+  , parseNumber :: Parser SExpr
+  , parseBool   :: Parser SExpr
+  }
+
+mkLiteralParsers ::
+  (LiteralParsersM -> LiteralParsersM) ->
+  LiteralParsers
+mkLiteralParsers f =
+  case f def of
+    LiteralParsersM{..} ->
+      let Just (Last parseString) = parseStringM
+          Just (Last parseNumber) = parseNumberM
+          Just (Last parseBool)   = parseBoolM in
+        LiteralParsers parseString parseNumber parseBool
+
+overrideStringP ::
+  Parser SExpr -> LiteralParsersM ->  LiteralParsersM
+overrideStringP sp lp = lp <>
+  LiteralParsersM
+  { parseStringM = Just $ Last sp
+  , parseNumberM = Nothing
+  , parseBoolM   = Nothing
+  }
+
+overrideNumberP ::
+  Parser SExpr -> LiteralParsersM ->  LiteralParsersM
+overrideNumberP np lp = lp <>
+  LiteralParsersM
+  { parseStringM = Nothing
+  , parseNumberM = Just $ Last np
+  , parseBoolM   = Nothing
+  }
+
+overrideBoolP ::
+  Parser SExpr -> LiteralParsersM ->  LiteralParsersM
+overrideBoolP bp lp = lp <>
+  LiteralParsersM
+  { parseStringM = Nothing
+  , parseNumberM = Nothing
+  , parseBoolM   = Just $ Last bp
+  }
+  
+instance Semigroup LiteralParsersM where
+  (<>)
+    (LiteralParsersM ps pn pb)
+    (LiteralParsersM ps' pn' pb') =
+    LiteralParsersM (ps <> ps') (pn <> pn') (pb <> pb')
+
+-- | Default parser for s-expression boolean literals
+parseBoolDef ::
+  Parser SExpr
+parseBoolDef = do
+  b <-  string "#t" <* notFollowedBy alphaNumChar
+    <|> string "#f" <* notFollowedBy alphaNumChar
+  case b of
+    "#t" -> return $ Bool True
+    "#f" -> return $ Bool False
+    _ -> fail "Not a boolean"
+  
+-- | Default parser for s-expression numeric literals
+parseNumberDef ::
+    Parser SExpr    -- ^ parser
+parseNumberDef = (Number . read) <$> some digitChar
+
+-- | Default parser for s-expression string literals
+parseStringDef ::
+    Parser SExpr    -- ^ parser
+parseStringDef = do
+    void $ char '"'
+    s <- many (noneOf "\"")
+    void $ char '"'
+    pure $ String s
+
+instance Default LiteralParsersM where
+  def = LiteralParsersM
+        { parseStringM = Just $ Last parseStringDef
+        , parseNumberM = Just $ Last parseNumberDef
+        , parseBoolM   = Just $ Last parseBoolDef
+        }
+
+instance Default LiteralParsers where
+  def = mkLiteralParsers def

--- a/lib/Text/SExpression/Internal.hs
+++ b/lib/Text/SExpression/Internal.hs
@@ -41,10 +41,8 @@ module Text.SExpression.Internal
     , overrideBoolP
     , overrideNumberP
     , overrideStringP
-    , def
     ) where
 
-import Data.Default (def)
 import Control.Applicative (empty)
 import Control.Monad (void)
 import Text.Megaparsec
@@ -71,7 +69,6 @@ import Text.Megaparsec.Char.Lexer
     , skipLineComment
     )
 import Text.SExpression.Types (Parser, SExpr(..))
-
 import Text.SExpression.Default
 
 sc :: Parser ()

--- a/lib/Text/SExpression/Internal.hs
+++ b/lib/Text/SExpression/Internal.hs
@@ -44,7 +44,7 @@ module Text.SExpression.Internal
     , def
     ) where
 
-import Data.Default (Default(..))
+import Data.Default (def)
 import Control.Applicative (empty)
 import Control.Monad (void)
 import Text.Megaparsec

--- a/lib/Text/SExpression/Internal.hs
+++ b/lib/Text/SExpression/Internal.hs
@@ -10,7 +10,7 @@ Portability : portable
 This module provides internal parser functions.
 -}
 
---{-# OPTIONS_GHC -Wall -Werror #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
 
 {-# LANGUAGE CPP #-}
 
@@ -25,7 +25,6 @@ This module provides internal parser functions.
 #endif
 #endif
 
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE FlexibleInstances #-}
 
@@ -48,7 +47,7 @@ module Text.SExpression.Internal
     ) where
 
 import Data.Default (Default(..))
-import Control.Applicative (empty, (*>))
+import Control.Applicative (empty)
 import Control.Monad (void)
 import Text.Megaparsec
     ( (<|>)

--- a/sexpr-parser.cabal
+++ b/sexpr-parser.cabal
@@ -24,7 +24,8 @@ library
   build-depends:
       base              >= 4.9 && < 4.13
     , megaparsec        >= 6.5 && < 7.1
-
+    , data-default      >= 0.6 && < 0.8
+    
 test-suite sexpr-parser-spec
   type:                 exitcode-stdio-1.0
   default-language:     Haskell2010

--- a/sexpr-parser.cabal
+++ b/sexpr-parser.cabal
@@ -21,6 +21,7 @@ library
       Text.SExpression
     , Text.SExpression.Internal
     , Text.SExpression.Types
+    , Text.SExpression.Default
   build-depends:
       base              >= 4.9 && < 4.13
     , megaparsec        >= 6.5 && < 7.1

--- a/sexpr-parser.cabal
+++ b/sexpr-parser.cabal
@@ -1,5 +1,5 @@
 name:                   sexpr-parser
-version:                0.1.1.2
+version:                0.2.0.0
 synopsis:               Simple s-expression parser
 description:
   This package provides a simple Megaparsec-based s-expression parser.

--- a/sexpr-parser.cabal
+++ b/sexpr-parser.cabal
@@ -38,8 +38,9 @@ test-suite sexpr-parser-spec
       base              >= 4.9 && < 4.13
     , hspec             >= 2.5 && < 2.8
     , megaparsec        >= 6.5 && < 7.1
+    , data-default      >= 0.6 && < 0.8
     , sexpr-parser
-
+                  
 executable sexpr-parser-z3-demo
   default-language:     Haskell2010
   hs-source-dirs:       z3-demo

--- a/spec/Text/SExpression/InternalSpec.hs
+++ b/spec/Text/SExpression/InternalSpec.hs
@@ -19,6 +19,7 @@ import Test.Hspec
     , shouldBe
     )
 import Text.Megaparsec (parse)
+import Data.Default (def)
 import Text.SExpression.Internal
     ( parseAtom
     , parseConsList
@@ -27,7 +28,6 @@ import Text.SExpression.Internal
     , parseQuoted
     , parseSExpr
     , parseStringDef
-    , def
     )
 import Text.SExpression.Types (SExpr(..))
 

--- a/z3-demo/Main.hs
+++ b/z3-demo/Main.hs
@@ -23,7 +23,7 @@ import System.Process
 import Text.Megaparsec (parse)
 import Text.Megaparsec.Char (char, string)
 import Text.Printf (printf)
-import Text.SExpression (Parser, SExpr(..), parseSExpr)
+import Text.SExpression (Parser, SExpr(..), parseSExpr, def)
 
 data Z3SATResult = Satisfied | Unsatisfied deriving Show
 
@@ -57,7 +57,7 @@ parseZ3SATResult = do
         _ -> error "Unreachable"
 
 parseZ3Output :: Parser Z3Output
-parseZ3Output = Z3Output <$> parseZ3SATResult <*> parseSExpr
+parseZ3Output = Z3Output <$> parseZ3SATResult <*> parseSExpr def
 
 checkSATWithZ3 :: String -> String -> IO (Either String (Z3SATResult, [(String, Bool)]))
 checkSATWithZ3 ctx input = do


### PR DESCRIPTION
Issue #4 

Example usage:
```haskell
myBoolP :: Parser SExpr
myBoolP = ...

myStrP :: Parser SExpr
myStrP = ...

myParseSExpr :: Parser SExpr
myParseSExpr = parseSExpr $ mkLiteralParsers $ 
  overrideBoolP myBoolP . overrideStringP myStrP

defParseSExpr :: Parser SExpr
defParseSExpr = parseSExpr def
```