### PR TITLE
Get the package to build with GHC 9.2.x

### DIFF
--- a/lib/Text/SExpression/Default.hs
+++ b/lib/Text/SExpression/Default.hs
@@ -26,6 +26,7 @@ module Text.SExpression.Default
   , parseBoolDef
   ) where
 
+import Data.Maybe (fromJust)
 import Data.Semigroup (Last(..))
 import Data.Default
 import Text.SExpression.Types (SExpr(..), Parser)
@@ -87,9 +88,9 @@ mkLiteralParsers ::
 mkLiteralParsers f =
   case f def of
     LiteralParsersM{..} ->
-      let Just (Last parseString) = parseStringM
-          Just (Last parseNumber) = parseNumberM
-          Just (Last parseBool)   = parseBoolM in
+      let Last parseString = fromJust parseStringM
+          Last parseNumber = fromJust parseNumberM
+          Last parseBool   = fromJust parseBoolM in
         LiteralParsers parseString parseNumber parseBool
 
 -- | String parser override function

--- a/sexpr-parser.cabal
+++ b/sexpr-parser.cabal
@@ -24,7 +24,7 @@ library
     , Text.SExpression.Default
   build-depends:
       base              >= 4.9 && < 5
-    , megaparsec        >= 6.5 && < 7.1
+    , megaparsec        >= 6.5 && < 9.3
     , data-default      >= 0.6 && < 0.8
 
 test-suite sexpr-parser-spec
@@ -36,8 +36,8 @@ test-suite sexpr-parser-spec
       Text.SExpression.InternalSpec
   build-depends:
       base              >= 4.9 && < 5
-    , hspec             >= 2.5 && < 2.8
-    , megaparsec        >= 6.5 && < 7.1
+    , hspec             >= 2.5 && < 2.10
+    , megaparsec        >= 6.5 && < 9.3
     , data-default      >= 0.6 && < 0.8
     , sexpr-parser
 
@@ -47,7 +47,7 @@ executable sexpr-parser-z3-demo
   main-is:              Main.hs
   build-depends:
       base              >= 4.9 && < 5
-    , bytestring        >= 0.10 && < 0.11
-    , megaparsec        >= 6.5 && < 7.1
+    , bytestring        >= 0.10 && < 0.12
+    , megaparsec        >= 6.5 && < 9.3
     , process           >= 1.6 && < 1.7
     , sexpr-parser

--- a/spec/Text/SExpression/InternalSpec.hs
+++ b/spec/Text/SExpression/InternalSpec.hs
@@ -8,7 +8,7 @@ Stability   : stable
 Portability : portable
 -}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
+{-# OPTIONS_GHC -Wall -Werror -Wno-incomplete-uni-patterns #-}
 
 module Text.SExpression.InternalSpec (spec) where
 

--- a/z3-demo/Main.hs
+++ b/z3-demo/Main.hs
@@ -8,7 +8,7 @@ Stability   : stable
 Portability : portable
 -}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
+{-# OPTIONS_GHC -Wall -Werror -Wno-incomplete-uni-patterns #-}
 
 module Main (main) where
 


### PR DESCRIPTION
- Update outdated dependencies
- Silence a couple instances of -Wincomplete-uni-patterns, where we're
  using `Just x` or `Right x` as a pattern where we know it can't fail.
  In one instance we use Data.Maybe.fromJust to do this since it's an
  easy fix, in the others we just locally disable the warning.

---

It would probably be better to set -Werror in a cabal.project file or the like, as this way packages that depend on this aren't broken by newer warnings; they'll only show up in development. But I didn't do that (1) in the interest of keeping this a small change, and (2) since I see you're using stack, and I wasn't sure off-hand what the equivalent was.